### PR TITLE
bugfix/countdown-when-time-hits-zero

### DIFF
--- a/src/components/shared/Countdown/Countdown.tsx
+++ b/src/components/shared/Countdown/Countdown.tsx
@@ -12,15 +12,15 @@ import {
 
 import './Countdown.scss';
 
+const initializeDurationObject = () => ({} as Record<TDuration, number>);
+
 interface ICountdownProps {
   unixTime: number;
   isLoading?: boolean;
 }
 
-// TODO! Fix delay in displaying countdown timer
-
-/* TODO! IMPORTANT: When upcoming mission countdown hits 0, timer starts increasing - indicating "Current Launch" time
-  Right now, this is being displayed:
+/* TECH-DEBT FIXED TO-CHECK IMPORTANT: When upcoming mission countdown hits 0, timer starts increasing - indicating "Current Launch" time
+Right now, this is being displayed:
   00
   DAYS
   
@@ -32,15 +32,28 @@ interface ICountdownProps {
   
   0-43
   SECONDS
-*/
+  */
 
 const Countdown: React.FC<ICountdownProps> = ({ unixTime, isLoading }) => {
-  // TODO! Fix any
-  const [durationObject, setDurationObject] = useState<Record<TDuration, number>>({} as any);
+  /* TODO I see two options here:
+    Current scenario: Nothing is displayed while !Object.entries(durationObject).length
+      Problems: - Delay in rendering countdown timer between isLoading === false and actual node render
+                - Height of div is 0 when there's no content, then icreases when timer countdown renders
+      Solutions: Either set minimum height for div so that it won't shrik when it's empty, or
+                 initialize all durationObject's properties to 0, so that 0 00 00 00 will be displayed
+                 while API data is being fetched 
+  */
+  const [durationObject, setDurationObject] = useState<Record<TDuration, number>>(() =>
+    initializeDurationObject(),
+  );
+  // We want to display a specific string whether event has happened or will happen
+  const [momentInTime, setMomentInTime] = useState<'next' | 'current' | ''>('');
 
   useEffect(() => {
     const now = moment().unix();
-    const diffTime = unixTime ? unixTime - now : 0;
+    const diffTime = moment(unixTime).diff(now);
+
+    diffTime > 0 ? setMomentInTime('next') : setMomentInTime('current');
 
     const countdownInterval = setInterval(() => {
       setDurationObject(getDurationInterval(diffTime));
@@ -55,6 +68,7 @@ const Countdown: React.FC<ICountdownProps> = ({ unixTime, isLoading }) => {
 
   return (
     <div className="countdown-container">
+      {Object.entries(durationObject).length ? <h3>{momentInTime} launch</h3> : null}
       {Object.entries(durationObject).map(([key]) => {
         return (
           <div className="countdown__content" key={key}>

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -8,17 +8,19 @@ export function typeGuardFunction<T>(object: T, key: string): boolean {
   return key in object;
 }
 
-// TODO: moment => Consider replacing `.duration` with `.diff`
+const getAbsoluteValue = (num: number) => Math.abs(num);
+
+// TODO TECH-DEBT solution has room for improvement
 export function getDurationInterval(
   unixTime: number,
   unit: DurationInputArg2 = 'milliseconds',
 ): Record<TDuration, number> {
   const duration = moment.duration(unixTime * MILLISECONDS_INTERVAL, unit);
   return {
-    days: duration.days(),
-    hours: duration.hours(),
-    minutes: duration.minutes(),
-    seconds: duration.seconds(),
+    days: getAbsoluteValue(duration.days()),
+    hours: getAbsoluteValue(duration.hours()),
+    minutes: getAbsoluteValue(duration.minutes()),
+    seconds: getAbsoluteValue(duration.seconds()),
   };
 }
 
@@ -32,6 +34,7 @@ export function getNestedObjectPropertyByPathName<T extends unknown>(
   );
 }
 
+// TODO Might be useless if better moment solution for countdown is implemented
 // USAGE ~ Format countdown numbers when they're less than 9
 export function formatDateNumber(input: number): string | number {
   // FIXME: When countdown hits 00, input arrives as `undefined` instead of `number`


### PR DESCRIPTION
bugfix / Fix Countdown component behavior when time hits zero by checking UNIX difference and passing it to Math.abs()