### PR TITLE
bugfix / Fix duplicated data in launches page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 1. Add light / dark mode
 2. Use styled-components - check out this about styled-components https://styled-components.com/docs/tooling
+3. Make navbar sticky
+4. Implement `ScrollToTop` component and add it into Launches page

--- a/src/components/pages/Launches.tsx
+++ b/src/components/pages/Launches.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useInView } from 'react-intersection-observer';
@@ -6,16 +6,15 @@ import { RouteComponentProps } from '@reach/router';
 import axios from 'axios';
 
 import { ApiEndpoints, BASE_URL } from 'api/urls';
-import { ILaunchQuery, ILaunchQueryPopulated } from 'schemas/launch_d';
+import { ILaunchQuery } from 'schemas/launch_d';
 
 import MainLayout from 'components/layout/MainLayout/MainLayout';
+import LaunchesItemCard from 'components/shared/LaunchesItemCard/LaunchesItemCard';
 
 // TODO Refactor component
 
 const Launches = (props: RouteComponentProps) => {
   const { ref, inView } = useInView();
-
-  const [launchesData, setLaunchesData] = useState<ILaunchQueryPopulated[]>([]);
 
   const {
     status,
@@ -29,7 +28,7 @@ const Launches = (props: RouteComponentProps) => {
     hasNextPage,
     hasPreviousPage,
   } = useInfiniteQuery(
-    ['projects'],
+    ['launches'],
     async ({ pageParam = 1 }) => {
       const res = await axios.post<ILaunchQuery>(
         `${BASE_URL}v5/${ApiEndpoints.QUERY_UPCOMING_LAUNCHES}`,
@@ -39,8 +38,6 @@ const Launches = (props: RouteComponentProps) => {
           },
         },
       );
-      const freshFetchedLaunches = res?.data?.docs || [];
-      setLaunchesData((prevFetchedLaunches) => [...prevFetchedLaunches, ...freshFetchedLaunches]);
       return res;
     },
     {
@@ -57,9 +54,11 @@ const Launches = (props: RouteComponentProps) => {
 
   return (
     <MainLayout>
-      {launchesData.map((launch) => (
-        <p key={launch.id}>{launch.name}</p>
-      ))}
+      {data?.pages?.map((page) => {
+        return page?.data?.docs?.map((launch) => (
+          <LaunchesItemCard data={launch} key={launch.id} />
+        ));
+      })}
       <button
         style={{ cursor: !hasNextPage || isFetchingNextPage ? 'not-allowed' : 'pointer' }}
         ref={ref}


### PR DESCRIPTION
Previously, I was using `useState` hook to store launches-related data in `Launches.tsx` component.
Such data was set in the state variable - the setter function was responsible for merging the previous data with the new one following the resolved Promise.
This approach was buggy as I soon realized that that data was being duplicated ( React was complaining about multiple, identical IDs in devtools console).

The easy fix was there all along: https://tanstack.com/query/v4/docs/examples/react/load-more-infinite-scroll?from=reactQueryV3&original=https://react-query-v3.tanstack.com/examples/load-more-infinite-scroll

As per this example in `react-query` official docs, `data` must be taken directly from the `data` object returned from `useInfiniteQuery` hook - no need for any weird `useState` workaround.

```
{data?.pages?.map((page) => {
   return page?.data?.docs?.map((launch) => (
      // Do stuff with fetched data
   ));
})}
```